### PR TITLE
Set origin option as an array instead of function

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -4,15 +4,11 @@ const cors = require('cors')
 
 const router = express.Router()
 
-const allowedOrigins = ['http://localhost:8080', 'http://localhost:3000', 'http://weareyourteam.herokuapp.com', 'http://dev-weareyourteam.herokuapp.com']
 const corsOptions = {
-  origin: (origin, callback) => {
-    if (allowedOrigins.indexOf(origin) !== -1) {
-      callback(null, true)
-    } else {
-      callback('Not allowed by CORS', false)
-    }
-  },
+  origin: [
+    /http:\/\/localhost:\d+/,
+    /https?:\/\/(dev-)?weareyourteam.herokuapp.com/,
+  ],
 }
 
 router.use('/api', cors(corsOptions), apiRoute)


### PR DESCRIPTION
Any origin that match a regex in the array should be whitelisted. It should also allow requests from the same origin (those with no Origin header automatically set).

